### PR TITLE
Added camera mode switches

### DIFF
--- a/src/EditorFunction/CameraModes.as
+++ b/src/EditorFunction/CameraModes.as
@@ -1,0 +1,58 @@
+namespace EditorHelpers
+{
+    array<string> CameraModesStr = {
+        "Orbital",
+        "Free"
+    };
+    [Setting category="Functions" name="Camera Modes: Enable" description="Enable"]
+    bool Setting_CameraMode_Enabled = true;
+    string Setting_CameraMode_CurrentMode = CameraModesStr[0];
+
+    class CameraModes : EditorHelpers::EditorFunction
+    {
+
+        bool SettingUpdated = false;
+
+        bool Enabled() override { return Setting_CameraMode_Enabled; }
+
+        void Update(float dt) override
+        {
+            if (!Enabled()) return;
+
+            if (SettingUpdated)
+            {
+                if (Setting_CameraMode_CurrentMode == CameraModesStr[1]) {
+                    Editor.CamMode = CGameCtnEditorCommon::_EUnnamedEnum::Free;
+                } else {
+                    Editor.CamMode = CGameCtnEditorCommon::_EUnnamedEnum::Orbital;
+                }
+                SettingUpdated = false;
+                return;
+            }
+        }
+
+        void RenderInterface_Display() override
+        {
+            if (!Enabled()) return;
+
+            if (settingToolTipsEnabled)
+            {
+                EditorHelpers::HelpMarker("Switch between Orbital (default) camera and Free camera.");
+                UI::SameLine();
+            }
+            if (UI::BeginCombo("Camera mode", Setting_CameraMode_CurrentMode)) {
+                if (UI::Selectable("Orbital (default)", false))
+                {
+                    Setting_CameraMode_CurrentMode = CameraModesStr[0];
+                    SettingUpdated = true;
+                }
+                else if (UI::Selectable("Free", false))
+                {
+                    Setting_CameraMode_CurrentMode = CameraModesStr[1];
+                    SettingUpdated = true;
+                }
+                UI::EndCombo();
+            }
+        }
+    }
+}

--- a/src/Main.as
+++ b/src/Main.as
@@ -4,7 +4,7 @@ bool settingWindowVisible = true;
 [Setting category="General" name="Tooltips Enabled"]
 bool settingToolTipsEnabled = true;
 
-array<EditorHelpers::EditorFunction@> functions = 
+array<EditorHelpers::EditorFunction@> functions =
 {
       EditorHelpers::Quicksave()
     , EditorHelpers::BlockHelpers()
@@ -16,6 +16,7 @@ array<EditorHelpers::EditorFunction@> functions =
     , EditorHelpers::FreeblockModePreciseRotation()
     , EditorHelpers::Hotkeys()
     , EditorHelpers::RotationRandomizer()
+    , EditorHelpers::CameraModes()
 };
 
 namespace Compatibility


### PR DESCRIPTION
Added possibility to have Free camera mode in editor,

like in-game, you have to use arrow keys to move the camera, use right click to move direction, and use mouse wheel to change FOV (zoom)

![image](https://user-images.githubusercontent.com/42576124/172395012-b6531cee-c000-45a6-bc24-74589e0eb80d.png)
