### PR TITLE
Precise free block translation

### DIFF
--- a/src/EditorFunction/FreeblockModePreciseTranslation.as
+++ b/src/EditorFunction/FreeblockModePreciseTranslation.as
@@ -1,15 +1,12 @@
 
+#if TMNEXT
 namespace EditorHelpers
 {
     namespace Compatibility
     {
         bool FreeblockModePreciseTranslationShouldBeActive(CGameCtnEditorFree@ editor)
         {
-#if TMNEXT
             return editor.Cursor.UseFreePos || editor.PluginMapType.PlaceMode == CGameEditorPluginMap::EPlaceMode::Item;
-#else
-            return false;
-#endif
         }
     }
 
@@ -70,3 +67,4 @@ namespace EditorHelpers
         }
     }
 }
+#endif

--- a/src/EditorFunction/FreeblockModePreciseTranslation.as
+++ b/src/EditorFunction/FreeblockModePreciseTranslation.as
@@ -1,0 +1,72 @@
+
+namespace EditorHelpers
+{
+    namespace Compatibility
+    {
+        bool FreeblockModePreciseTranslationShouldBeActive(CGameCtnEditorFree@ editor)
+        {
+#if TMNEXT
+            return editor.Cursor.UseFreePos || editor.PluginMapType.PlaceMode == CGameEditorPluginMap::EPlaceMode::Item;
+#else
+            return false;
+#endif
+        }
+    }
+
+    [Setting category="Functions" name="FreeblockModePreciseTranslation: Enabled" description="Uncheck to disable all plugin functions related to Block Precise Rotation"]
+    bool Settings_FreeblockModePreciseTranslation_Enabled = true;
+    [Setting category="Functions" hidden]
+    bool Settings_FreeblockModePreciseTranslation_ApplyTranslation = false;
+
+    class FreeblockModePreciseTranslation : EditorHelpers::EditorFunction
+    {
+        vec3 translation;
+        vec3 prevPosInMap;
+
+
+        bool Enabled() override { return Settings_FreeblockModePreciseTranslation_Enabled; }
+
+        void Init() override
+        {
+            if (Editor is null || !Enabled() || FirstPass)
+            {
+                translation.x = 0.0f;
+                translation.y = 0.0f;
+                translation.z = 0.0f;
+            }
+        }
+
+        void RenderInterface_Build() override
+        {
+            if (!Enabled()) return;
+
+            UI::PushID("FreeblockModePreciseTranslation::RenderInterface");
+
+            UI::TextDisabled("\tTranslation");
+            if (settingToolTipsEnabled)
+            {
+                EditorHelpers::HelpMarker("Sets the translation offset when in free block mode.");
+                UI::SameLine();
+            }
+            Settings_FreeblockModePreciseTranslation_ApplyTranslation = UI::Checkbox("Apply Custom Translation", Settings_FreeblockModePreciseTranslation_ApplyTranslation);
+            translation.x = UI::InputFloat("Translation x", translation.x,0.1);
+            translation.y = UI::InputFloat("Translation y", translation.y,0.1);
+            translation.z = UI::InputFloat("Translation z", translation.z,0.1);
+
+            UI::PopID();
+        }
+
+        void Update(float) override
+        {
+            if (!Enabled() || Editor is null) return;
+            if (Compatibility::FreeblockModePreciseTranslationShouldBeActive(Editor) && Settings_FreeblockModePreciseTranslation_ApplyTranslation)
+            {
+                if(Math::Distance2(Editor.Cursor.FreePosInMap,prevPosInMap) > 0.0001)
+                {
+                    Editor.Cursor.FreePosInMap += translation;
+                    prevPosInMap = Editor.Cursor.FreePosInMap;  
+                }
+            }
+        }
+    }
+}

--- a/src/Main.as
+++ b/src/Main.as
@@ -16,7 +16,9 @@ array<EditorHelpers::EditorFunction@> functions =
     , EditorHelpers::FreeblockModePreciseRotation()
     , EditorHelpers::Hotkeys()
     , EditorHelpers::RotationRandomizer()
+    #if TMNEXT
     , EditorHelpers::FreeblockModePreciseTranslation()
+    #endif
     , EditorHelpers::MoodChanger()
     , EditorHelpers::CameraModes()
     , EditorHelpers::LocatorCheck()

--- a/src/Main.as
+++ b/src/Main.as
@@ -16,6 +16,7 @@ array<EditorHelpers::EditorFunction@> functions =
     , EditorHelpers::FreeblockModePreciseRotation()
     , EditorHelpers::Hotkeys()
     , EditorHelpers::RotationRandomizer()
+    , EditorHelpers::FreeblockModePreciseTranslation()
     , EditorHelpers::MoodChanger()
     , EditorHelpers::CameraModes()
     , EditorHelpers::LocatorCheck()


### PR DESCRIPTION
Sometimes we also need to precisely place blocks in free mode, for example the default free mode placement step does not allow us to match the road height of Tm2.
![PreciseTranslation](https://user-images.githubusercontent.com/17177468/179032208-8c96f522-b032-4c69-8ad9-2764b8f514d1.png)

[left] Too high (+1m) [middle] Too low (+0m) [right] Perfect (+0.345m)

This module only work for TMNEXT obviously, that's why it's completely disabled for the other games.
