### PR TITLE
"Fix" for hotkeys with closed window

### DIFF
--- a/src/EditorFunction/Hotkeys.as
+++ b/src/EditorFunction/Hotkeys.as
@@ -274,9 +274,9 @@ namespace EditorHelpers
                 return;
             }
 
-            if (!Enabled() || Compatibility::EditorIsNull() || Compatibility::IsMapTesting() || !settingWindowVisible)
+            if (!Enabled() || Compatibility::EditorIsNull() || Compatibility::IsMapTesting())
             {
-                Debug("!Enabled():" + tostring(!Enabled()) + " Compatibility::EditorIsNull():" + tostring(Compatibility::EditorIsNull()) + " Compatibility::IsMapTesting():" + tostring(Compatibility::IsMapTesting()) + " !settingWindowVisible:" + tostring(!settingWindowVisible));
+                Debug("!Enabled():" + tostring(!Enabled()) + " Compatibility::EditorIsNull():" + tostring(Compatibility::EditorIsNull()) + " Compatibility::IsMapTesting():" + tostring(Compatibility::IsMapTesting()));
                 Debug_LeaveMethod();
                 return;
             }


### PR DESCRIPTION
Altough I do not know if this is intentional; hotkeys for e.g. Airblock mode don't work when the window is closed. This is only a minor inconvenience, but does get a little bit annoying at times. 
I am unaware of any issues this may cause, but from some quick testing I haven't stumbled upon any so far. Regardless of whether the behaviour (needing the window opened to use hotkeys) is intentional or not, my preference would go towards having them work by default without having the window opened.