### PR TITLE
Fix for TM update of 14-12-2022

### DIFF
--- a/src/EditorFunction/PodiumReminder.as
+++ b/src/EditorFunction/PodiumReminder.as
@@ -7,7 +7,7 @@ namespace EditorHelpers
         {
             bool containsPodiumInfo = false;
 #if TMNEXT
-            containsPodiumInfo = itemModel !is null && itemModel.PodiumInfo !is null;
+            containsPodiumInfo = itemModel !is null && itemModel.Name == "Podium";
 #endif
             return containsPodiumInfo;
         }


### PR DESCRIPTION
Fixes a newly introduced issue after the TM update of today.
The error:
```log
[    ScriptEngine] [15:15:36] [EditorHelpers]  src/EditorFunction/PodiumReminder.as (6, 9) : INFO : Compiling bool ItemContainsPodiumInfo(CGameItemModel@)
[    ScriptEngine] [15:15:36] [EditorHelpers]  src/EditorFunction/PodiumReminder.as (10, 65) :  ERR : 'PodiumInfo' is not a member of 'CGameItemModel'
[    ScriptEngine] [15:15:36]  Script compilation failed!
[    ScriptEngine] [15:15:36]  Loaded zipped plugin 'EditorHelpers' (version 5.9)
```
`PodiumInfo` no longer seems to be a member of the ItemModel, so I changed it to `Name` (which should always be "Podium"? but not sure if there is a better way to check if the string exists), which seems to work fine... I have no idea if it matters for the functionality, but everything seemed to work as expected (notification on save without podium placed, and no notif on save with the podium placed).

There might be more issues, but I haven't found any other than this yet.